### PR TITLE
Fix: Prevent exposing MongoDB and Redis to host

### DIFF
--- a/docker-compose.local.yaml
+++ b/docker-compose.local.yaml
@@ -1,24 +1,33 @@
 version: '3'
 
+networks:
+  sh:
+
 services:
   mongodb:
     image: mongo:latest
     volumes:
     - ./data:/data/db
-    ports: 
-      - 27017:27017
+    expose: 
+      - 27017
+    networks:
+      - sh
 
   redis:
     image: redis:latest
-    ports:
-      - 6379:6379
+    expose:
+      - 6379
+    networks:
+      - sh
 
   secret-hitler:
     build: .
-    restart: always
     depends_on:
       - mongodb
       - redis
+    networks:
+      - sh
+    restart: always
     environment: 
       MONGODB_URI: mongodb://mongodb:27017
       REDIS_HOST: redis

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,23 +1,33 @@
 version: '3'
 
+networks:
+  sh:
+
 services:
   mongodb:
     image: mongo:latest
     volumes:
     - ./data:/data/db
-    ports: 
-      - 27017:27017
+    expose: 
+      - 27017
+    networks:
+      - sh
 
   redis:
     image: redis:latest
-    ports:
-      - 6379:6379
+    expose:
+      - 6379
+    networks:
+      - sh
 
   secret-hitler:
     image: addono/secret-hitler:latest
     depends_on:
       - mongodb
       - redis
+    networks:
+      - sh
+    restart: always
     environment: 
       MONGODB_URI: mongodb://mongodb:27017
       REDIS_HOST: redis


### PR DESCRIPTION
Thanks @techge for raising this issue in #11 .

I had to cherry-pick it, because I rebased my commits on master on top of everything which landed from upstream. (I misconfigured my bot which pulls from upstream to overwrite master and when I was fixing it I accidentally rebased changing the Git history of the commits you include in your PR.)

What do you think @techge? I used `expose` instead of ephemaral ports, as this would bind still bind the DB to ports on the host, however now these ports would be picked at random.  

https://stackoverflow.com/a/40801773/7500339